### PR TITLE
[FEAT] SOUNDEFFECT-009: 유사한 효과음 조회 API 생성

### DIFF
--- a/src/main/java/capstone/ses/controller/SoundEffectController.java
+++ b/src/main/java/capstone/ses/controller/SoundEffectController.java
@@ -5,19 +5,15 @@ import capstone.ses.dto.soundeffect.SoundEffectCondition;
 import capstone.ses.dto.soundeffect.SoundEffectDto;
 import capstone.ses.dto.system.Result;
 import capstone.ses.dto.system.ResultCode;
-import capstone.ses.dto.system.Error;
 import capstone.ses.repository.SoundEffectTypeRepository;
 import capstone.ses.service.SoundEffectService;
 import capstone.ses.service.SoundEffectTagService;
 import capstone.ses.service.YoutubeDownloadService;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -27,7 +23,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
@@ -167,5 +162,14 @@ public class SoundEffectController {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
+    }
+
+    @GetMapping("/soundeffect/{soundEffectId}/relative")
+    public Result searchSoundEffectRelative(@PathVariable Long soundEffectId) {
+        try {
+            return new Result(ResultCode.SUCCESS, soundEffectService.searchRelativeSoundEffects(soundEffectId));
+        } catch (IllegalStateException e) {
+            return new Result(ResultCode.FAIL, e.getMessage(), "400");
+        }
     }
 }

--- a/src/main/java/capstone/ses/repository/SoundEffectRepositoryCustom.java
+++ b/src/main/java/capstone/ses/repository/SoundEffectRepositoryCustom.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface SoundEffectRepositoryCustom {
     List<SoundEffect> searchSoundEffects(SoundEffectCondition soundEffectCondition);
+    List<SoundEffect> searchRelativeSoundEffects(List<Long> soundEffectTagIds, Long soundEffectId);
 }

--- a/src/main/java/capstone/ses/repository/SoundEffectTagQueryRepository.java
+++ b/src/main/java/capstone/ses/repository/SoundEffectTagQueryRepository.java
@@ -1,5 +1,7 @@
 package capstone.ses.repository;
 
+import capstone.ses.domain.soundeffect.QSoundEffect;
+import capstone.ses.domain.soundeffect.QSoundEffectSoundEffectTagRel;
 import capstone.ses.dto.soundeffect.QSoundEffectTagDto;
 import capstone.ses.dto.soundeffect.SoundEffectTagDto;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -8,6 +10,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static capstone.ses.domain.soundeffect.QSoundEffect.soundEffect;
+import static capstone.ses.domain.soundeffect.QSoundEffectSoundEffectTagRel.soundEffectSoundEffectTagRel;
 import static capstone.ses.domain.soundeffect.QSoundEffectTag.soundEffectTag;
 
 @Repository
@@ -22,6 +26,15 @@ public class SoundEffectTagQueryRepository {
                         soundEffectTag.name
                 ))
                 .from(soundEffectTag)
+                .fetch();
+    }
+
+    public List<Long> findAllBySoundEffectId(long soundEffectId) {
+        return queryFactory
+                .select(soundEffectTag.id)
+                .from(soundEffectTag)
+                .innerJoin(soundEffectSoundEffectTagRel).on(soundEffectTag.eq(soundEffectSoundEffectTagRel.soundEffectTag))
+                .where(soundEffect.id.eq(soundEffectId))
                 .fetch();
     }
 }

--- a/src/main/java/capstone/ses/service/SoundEffectService.java
+++ b/src/main/java/capstone/ses/service/SoundEffectService.java
@@ -7,10 +7,7 @@ import capstone.ses.dto.soundeffect.SoundEffectCondition;
 import capstone.ses.dto.soundeffect.SoundEffectDto;
 import capstone.ses.dto.soundeffect.SoundEffectTagDto;
 import capstone.ses.dto.soundeffect.SoundEffectTypeDto;
-import capstone.ses.repository.SoundEffectRepository;
-import capstone.ses.repository.SoundEffectSoundEffectTagRepository;
-import capstone.ses.repository.SoundEffectTagRepository;
-import capstone.ses.repository.SoundEffectTypeRepository;
+import capstone.ses.repository.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +24,7 @@ public class SoundEffectService {
     private final SoundEffectTagRepository soundEffectTagRepository;
     private final SoundEffectTypeRepository soundEffectTypeRepository;
     private final SoundEffectSoundEffectTagRepository soundEffectSoundEffectTagRepository;
+    private final SoundEffectTagQueryRepository soundEffectTagQueryRepository;
 
     public SoundEffectDto searchSoundEffect(Long soundEffectId) {
         SoundEffect soundEffect = soundEffectRepository.findById(soundEffectId).orElseThrow(() -> new EntityNotFoundException("not exist soundeffect."));
@@ -59,6 +57,38 @@ public class SoundEffectService {
         List<SoundEffectDto> soundEffectDtos = new ArrayList<>();
 
         for (SoundEffect soundEffect : soundEffectRepository.searchSoundEffects(soundEffectCondition)) {
+
+            List<SoundEffectTagDto> soundEffectTagDtos = new ArrayList<>();
+
+            for (SoundEffectSoundEffectTagRel soundEffectSoundEffectTagRel : soundEffectSoundEffectTagRepository.findBySoundEffect(soundEffect)) {
+                soundEffectTagDtos.add(SoundEffectTagDto.of(soundEffectSoundEffectTagRel.getSoundEffectTag()));
+            }
+
+            List<SoundEffectTypeDto> soundEffectTypeDtos = new ArrayList<>();
+
+            for (SoundEffectType soundEffectType : soundEffectTypeRepository.findBySoundEffect(soundEffect)) {
+                soundEffectTypeDtos.add(SoundEffectTypeDto.of(soundEffectType));
+            }
+
+            soundEffectDtos.add(SoundEffectDto.builder()
+                    .soundEffectId(soundEffect.getId())
+                    .soundEffectName(soundEffect.getName())
+                    .description(soundEffect.getDescription())
+                    .summary(soundEffect.getSummary())
+//                    .createBy(soundEffect.get)
+                    .createdAt(soundEffect.getCreatedDate())
+                    .soundEffectTags(soundEffectTagDtos)
+                    .soundEffectTypes(soundEffectTypeDtos)
+                    .build());
+        }
+
+        return soundEffectDtos;
+    }
+
+    public List<SoundEffectDto> searchRelativeSoundEffects(Long soundEffectId) {
+        List<SoundEffectDto> soundEffectDtos = new ArrayList<>();
+
+        for (SoundEffect soundEffect : soundEffectRepository.searchRelativeSoundEffects(soundEffectTagQueryRepository.findAllBySoundEffectId(soundEffectId), soundEffectId)) {
 
             List<SoundEffectTagDto> soundEffectTagDtos = new ArrayList<>();
 


### PR DESCRIPTION
###변경사항
- SOUNDEFFECT-009: 유사한 효과음 API 구현
- #18 
### How to 구현?
- querydsl 활용하여 구현
### 📸 스크린샷
![localhost_8080_api_v1_soundeffect_2_relative](https://github.com/2024-1-CapstoneDesign/ses_server/assets/96684524/617a901a-7b84-45d9-a4c0-8d3a3e302fe1)
