### PR TITLE
[REFACTOR] createdBy 주석 및 @ModelAttribute -> Requestparam으로 수정

### DIFF
--- a/src/main/java/capstone/ses/controller/SoundEffectController.java
+++ b/src/main/java/capstone/ses/controller/SoundEffectController.java
@@ -118,9 +118,10 @@ public class SoundEffectController {
     @PostMapping("/soundeffect/search")
     public Result searchSoundEffectDirect(
             @RequestHeader(value = "Authorization", required = false) String accessToken,
-            @ModelAttribute @Valid MultipartFile file) {
+            @RequestParam("file") @Valid MultipartFile file) {
+
         if (file.isEmpty()) {
-            return new Result(ResultCode.FAIL, "not found", "300");
+            return new Result(ResultCode.FAIL, "file이 전송되지 않았습니다.", "300");
         }
 
         try {

--- a/src/main/java/capstone/ses/service/SoundEffectService.java
+++ b/src/main/java/capstone/ses/service/SoundEffectService.java
@@ -304,7 +304,7 @@ public class SoundEffectService {
                         .soundEffectName(soundEffectByName.getName())
                         .description(soundEffectByName.getDescription())
                         .summary(soundEffectByName.getSummary())
-                        .createBy(memberRepository.findById(soundEffectByName.getCreatedBy()).get().getName())
+//                        .createBy(memberRepository.findById(soundEffectByName.getCreatedBy()).get().getName())
                         .isLiked(soundEffectRepository.checkLikedSoundEffecet(soundEffectByName, memberId))
                         .createdAt(soundEffectByName.getCreatedDate())
                         .soundEffectTags(soundEffectTagDtos)


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
`java.lang.IllegalArgumentException: Name for argument of type [org.springframework.web.multipart.MultipartFile] not specified, and parameter name information not available via reflection. Ensure that the compiler uses the '-parameters' flag. `
에러 발생

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- [ ] `@ModelAttribute` -> `@RequestParam`으로 수정
- [ ] 에러방지를 위해 value option 추가

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
- 파일이 비어서 오면 300 에러 리턴

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
- `@ModelAttribute`는 DTO에 매핑하는 경우에 사용된다고 함
- 그냥 form-data로 데이터를 받는 경우 `@RequestParam`으로 받는 것이 좋음

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|postman 테스트 결과|<img width="1058" alt="스크린샷 2024-12-02 오후 5 27 01" src="https://github.com/user-attachments/assets/e473fd94-3e80-4ded-a66a-275b402acc52">|

